### PR TITLE
Add support for nulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ npm i --save ts-optchain
 
 ### Requirements
 
-* NodeJS >= 6
-* TypeScript >= 2.8
+- NodeJS >= 6
+- TypeScript >= 2.8
 
 ## Example Usage
 
@@ -42,7 +42,6 @@ const x: I = {
   c: [{ u: { v: -100 } }, { u: { v: 200 } }, {}, { u: { v: -300 } }],
 };
 
-
 // Here are a few examples of deep object traversal using (a) optional chaining vs
 // (b) logic expressions. Each of the following pairs are equivalent in
 // result. Note how the benefits of optional chaining accrue with
@@ -61,18 +60,18 @@ oc(x).c[100].u.v(); // undefined
 x.c && x.c[100] && x.c[100].u && x.c[100].u.v;
 
 oc(x).c[100].u.v(1234); // 1234
-x.c && x.c[100] && x.c[100].u && x.c[100].u.v || 1234;
+(x.c && x.c[100] && x.c[100].u && x.c[100].u.v) || 1234;
 
 oc(x).e.f(); // undefined
 x.e && x.e.f;
 
 oc(x).e.f('optional default value'); // 'optional default value'
-x.e && x.e.f || 'optional default value';
+(x.e && x.e.f) || 'optional default value';
 
 // NOTE: working with function value types can be risky. Additional run-time
 // checks to verify that object types are functions before invocation are advised!
 oc(x).e.g(() => 'Yo Yo')(); // 'Yo Yo'
-(x.e && x.e.g || (() => 'Yo Yo'))();
+((x.e && x.e.g) || (() => 'Yo Yo'))();
 ```
 
 ## Problem
@@ -101,7 +100,7 @@ Without support for optional chaining built into TypeScript yet, an implementati
 
 ```typescript
 function getHomeStreet(user: IUser, defaultValue?: string) {
-  return user.home && user.home.address && user.home.address.street || defaultValue;
+  return (user.home && user.home.address && user.home.address.street) || defaultValue;
 }
 ```
 
@@ -117,9 +116,9 @@ function getHomeStreet(user: IUser, defaultValue?: string) {
 
 However, when using tools like `lodash` the developer loses the benefits of:
 
-* Compile-time validation of the path `home.address.street`
-* Compile-time validation of the expected type of the value at `home.address.street`
-* Development-time code-completion assistance when manipulating the path `home.address.street` using tools like Visual Studio Code.
+- Compile-time validation of the path `home.address.street`
+- Compile-time validation of the expected type of the value at `home.address.street`
+- Development-time code-completion assistance when manipulating the path `home.address.street` using tools like Visual Studio Code.
 
 ## Solution
 
@@ -185,7 +184,7 @@ const result = oc(thing).getter(() => 'Default Getter')();
 
 ## <a name="related"></a>Related Resources
 
-* [Optional Chaining for JavaScript (TC39 Proposal)](https://github.com/tc39/proposal-optional-chaining)
+- [Optional Chaining for JavaScript (TC39 Proposal)](https://github.com/tc39/proposal-optional-chaining)
 
 ## License
 

--- a/src/__tests__/ts-optchain-test.ts
+++ b/src/__tests__/ts-optchain-test.ts
@@ -11,9 +11,9 @@ describe('ts-optchain', () => {
   it('sanity checks', () => {
     interface X {
       a: string;
-      b: { d: string; };
+      b: { d: string };
       c: number[];
-      d: { e: string; } | null;
+      d: { e: string } | null;
     }
 
     const x = oc<X>({
@@ -22,7 +22,7 @@ describe('ts-optchain', () => {
         d: 'world',
       },
       c: [-100, 200, -300],
-      d: null
+      d: null,
     });
 
     expect(x.a()).toEqual('hello');
@@ -64,9 +64,11 @@ describe('ts-optchain', () => {
     expect(oc(x).b.d()).toEqual(x.b && x.b.d);
     expect(oc(x).c[0].u.v()).toEqual(x.c && x.c[0] && x.c[0].u && (x as any).c[0].u.v);
     expect(oc(x).c[100].u.v()).toEqual(x.c && x.c[100] && x.c[100].u && (x as any).c[100].u.v);
-    expect(oc(x).c[100].u.v(1234)).toEqual(x.c && x.c[100] && x.c[100].u && (x as any).c[100].u.v || 1234);
+    expect(oc(x).c[100].u.v(1234)).toEqual(
+      (x.c && x.c[100] && x.c[100].u && (x as any).c[100].u.v) || 1234,
+    );
     expect(oc(x).e.f()).toEqual(x.e && x.e.f);
-    expect(oc(x).e.f('optional default value')).toEqual(x.e && x.e.f || 'optional default value');
-    expect(oc(x).e.g(() => 'Yo Yo')()).toEqual((x.e && x.e.g || (() => 'Yo Yo'))());
+    expect(oc(x).e.f('optional default value')).toEqual((x.e && x.e.f) || 'optional default value');
+    expect(oc(x).e.g(() => 'Yo Yo')()).toEqual(((x.e && x.e.g) || (() => 'Yo Yo'))());
   });
 });

--- a/src/__tests__/ts-optchain-test.ts
+++ b/src/__tests__/ts-optchain-test.ts
@@ -13,7 +13,7 @@ describe('ts-optchain', () => {
       a: string;
       b: { d: string; };
       c: number[];
-      d?: { e: string; };
+      d: { e: string; } | null;
     }
 
     const x = oc<X>({
@@ -22,6 +22,7 @@ describe('ts-optchain', () => {
         d: 'world',
       },
       c: [-100, 200, -300],
+      d: null
     });
 
     expect(x.a()).toEqual('hello');

--- a/src/__tests__/ts-optchain-test.ts
+++ b/src/__tests__/ts-optchain-test.ts
@@ -14,6 +14,7 @@ describe('ts-optchain', () => {
       b: { d: string };
       c: number[];
       d: { e: string } | null;
+      e: { f: boolean } | null;
     }
 
     const x = oc<X>({
@@ -23,6 +24,7 @@ describe('ts-optchain', () => {
       },
       c: [-100, 200, -300],
       d: null,
+      e: { f: false },
     });
 
     expect(x.a()).toEqual('hello');
@@ -32,6 +34,7 @@ describe('ts-optchain', () => {
     expect(x.c[100](1234)).toEqual(1234);
     expect(x.d.e()).toBeUndefined();
     expect(x.d.e('optional default value')).toEqual('optional default value');
+    expect(x.e.f()).toEqual(false);
     expect((x as any).y.z.a.b.c.d.e.f.g.h.i.j.k()).toBeUndefined();
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,11 +107,8 @@ export function oc<T>(data?: T): OCType<T> {
     {
       get: (target, key) => {
         const obj: any = target();
-        if ('object' !== typeof obj) {
-          return oc();
-        }
 
-        return oc(obj[key]);
+        return oc(typeof obj === 'object' ? obj[key] : undefined);
       },
     },
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,6 @@
  */
 export type Defined<T> = Exclude<T, undefined>;
 
-
 ////////////////////////////
 //
 // IDataAccessor Definition
@@ -47,7 +46,7 @@ export interface IDataAccessor<T> {
  * `ObjectWrapper` gives TypeScript visibility into the properties of
  * an `OCType` object at compile-time.
  */
-export type ObjectWrapper<T> = { [K in keyof T]-?: OCType<Defined<T[K]>> };
+export type ObjectWrapper<T> = { [K in keyof T]-?: OCType<T[K]> };
 
 /**
  * `ArrayWrapper` gives TypeScript visibility into the `OCType` values of an array
@@ -69,7 +68,6 @@ export type DataWrapper<T> = T extends any[]
     ? ObjectWrapper<T>
     : IDataAccessor<T>;
 
-
 /////////////////////////////////////
 //
 // OCType Definitions
@@ -79,8 +77,7 @@ export type DataWrapper<T> = T extends any[]
 /**
  * An object that supports optional chaining
  */
-export type OCType<T> = IDataAccessor<T> & DataWrapper<T>;
-
+export type OCType<T> = IDataAccessor<T> & DataWrapper<NonNullable<T>>;
 
 /**
  * Proxies access to the passed object to support optional chaining w/ default values.
@@ -108,7 +105,7 @@ export type OCType<T> = IDataAccessor<T> & DataWrapper<T>;
  */
 export function oc<T>(data?: T): OCType<T> {
   return new Proxy(
-    ((defaultValue?: Defined<T>) => (data !== undefined ? data : defaultValue)) as OCType<T>,
+    ((defaultValue?: Defined<T>) => (data || defaultValue)) as OCType<T>,
     {
       get: (target, key) => {
         const obj: any = target();

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ export type ObjectWrapper<T> = { [K in keyof T]-?: OCType<T[K]> };
 export interface ArrayWrapper<T> {
   length: OCType<number>;
   [K: number]: OCType<T>;
-};
+}
 
 /**
  * `DataWrapper` selects between `ArrayWrapper`, `ObjectWrapper`, and `IDataAccessor`
@@ -64,9 +64,7 @@ export interface ArrayWrapper<T> {
  */
 export type DataWrapper<T> = T extends any[]
   ? ArrayWrapper<T[number]>
-  : T extends object
-    ? ObjectWrapper<T>
-    : IDataAccessor<T>;
+  : T extends object ? ObjectWrapper<T> : IDataAccessor<T>;
 
 /////////////////////////////////////
 //
@@ -104,17 +102,14 @@ export type OCType<T> = IDataAccessor<T> & DataWrapper<NonNullable<T>>;
  *   (x as any).y.z.a.b.c.d.e.f.g.h.i.j.k() === undefined
  */
 export function oc<T>(data?: T): OCType<T> {
-  return new Proxy(
-    ((defaultValue?: Defined<T>) => (data || defaultValue)) as OCType<T>,
-    {
-      get: (target, key) => {
-        const obj: any = target();
-        if ('object' !== typeof obj) {
-          return oc();
-        }
+  return new Proxy(((defaultValue?: Defined<T>) => data || defaultValue) as OCType<T>, {
+    get: (target, key) => {
+      const obj: any = target();
+      if ('object' !== typeof obj) {
+        return oc();
+      }
 
-        return oc(obj[key]);
-      },
+      return oc(obj[key]);
     },
-  );
+  });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,13 @@ export interface IDataAccessor<T> {
    * Data accessor with default value.
    * @param defaultValue
    */
-  (defaultValue: Defined<T>): Defined<T>;
+  (defaultValue: NonNullable<T>): NonNullable<T>;
+
+  /**
+   * Data accessor with null default value.
+   * @param defaultValue
+   */
+  (nullDefaultValue: T extends null ? null : never): Defined<T>;
 }
 
 ///////////////////////////

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,14 +102,17 @@ export type OCType<T> = IDataAccessor<T> & DataWrapper<NonNullable<T>>;
  *   (x as any).y.z.a.b.c.d.e.f.g.h.i.j.k() === undefined
  */
 export function oc<T>(data?: T): OCType<T> {
-  return new Proxy(((defaultValue?: Defined<T>) => data || defaultValue) as OCType<T>, {
-    get: (target, key) => {
-      const obj: any = target();
-      if ('object' !== typeof obj) {
-        return oc();
-      }
+  return new Proxy(
+    ((defaultValue?: Defined<T>) => (data == null ? defaultValue : data)) as OCType<T>,
+    {
+      get: (target, key) => {
+        const obj: any = target();
+        if ('object' !== typeof obj) {
+          return oc();
+        }
 
-      return oc(obj[key]);
+        return oc(obj[key]);
+      },
     },
-  });
+  );
 }


### PR DESCRIPTION
## Description
This library should handle cases when some key in nested path is `null`. As we can see from the specs https://github.com/tc39/proposal-optional-chaining#base-case optional chaining in deed should handle nulls same way as `undefined`

## Test Plan
I have added test case with null

Tell me what do you think :)
Fixes #6 
