### PR TITLE
 target "ES3" (currently doesn't support IE11 etc)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "outDir": "dist",
     "strict": true,
     "strictNullChecks": true,
-    "target": "es2015",
+    "target": "ES3",
   },
   "exclude": ["node_modules"],
   "include": ["src"]


### PR DESCRIPTION
Current target is "es2015" which means it breaks in IE11 etc (because of the arrow functions, if not other reasons too)
