### PR TITLE
Change tsconfig target to es5 for arrow function transpilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "outDir": "dist",
     "strict": true,
     "strictNullChecks": true,
-    "target": "es2015",
+    "target": "es5",
   },
   "exclude": ["node_modules"],
   "include": ["src"]


### PR DESCRIPTION
## Description

This PR aims to solve the problem reported on #13 by changing the `tsconfig.json` target from `es2015` to `es5`, which would make TypeScript transpile ES6 code (i.e. arrow functions) into legacy code supported by older browsers and platforms.

Although a core part of this tool is the use of JavaScript `Proxy`, those can be polyfilled. Syntax, on the other hand and especially in node dependencies, is harder to fix. As there is no clear benefit in outputting ES6-compatible code, changing the target to ES5 brings some benefit with no costs.

## Test Plan

Jest tests were run with `npm run test` and they passed. No side effects were noticed.