### PR TITLE
[Spike] Allow access to all branches for union types.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,11 @@
  * A generic type that cannot be `undefined`.
  */
 type Defined<T> = Exclude<T, undefined>;
+type UnionToIntersection<U> = (U extends any
+  ? (k: U) => void
+  : never) extends ((k: infer I) => void)
+  ? I
+  : never;
 
 /**
  * Data accessor interface to dereference the value of the `TSOCType`.
@@ -49,12 +54,16 @@ interface TSOCArrayWrapper<T> {
  */
 type TSOCDataWrapper<T> = T extends any[]
   ? TSOCArrayWrapper<T[number]>
-  : T extends object ? TSOCObjectWrapper<T> : TSOCDataAccessor<T>;
+  : T extends object
+  ? TSOCObjectWrapper<T>
+  : TSOCDataAccessor<T>;
 
 /**
  * An object that supports optional chaining
  */
-type TSOCType<T> = TSOCDataAccessor<T> & TSOCDataWrapper<NonNullable<T>>;
+type TSOCType<T> = UnionToIntersection<TSOCTypeIntersected<T>>;
+type TSOCTypeIntersected<T> = TSOCDataAccessor<T> &
+  TSOCDataWrapper<NonNullable<T>>;
 
 /**
  * Optional chaining with default values. To inspect a property value in

--- a/src/__tests__/types.ts
+++ b/src/__tests__/types.ts
@@ -31,6 +31,15 @@ interface X {
   getter?: () => string;
 }
 
+interface One {
+  deeplyNested?: {
+    maybeNumber?: number | null;
+  };
+}
+interface DeepUnion {
+  a?: One | string;
+}
+
 declare const x: X;
 
 const resWithDefault = oc(x).a.b("");
@@ -46,6 +55,19 @@ assert<Has<typeof resUnion, "bar">>(true);
 // Does not have null or undefined
 assert<Has<typeof resUnion, undefined>>(false);
 assert<Has<typeof resUnion, null>>(false);
+
+declare const deepUnion: DeepUnion;
+// Handles complex unions
+const resShallowUnion = oc(deepUnion).a("value");
+assert<Has<typeof resShallowUnion, string | One>>(true);
+
+const resUnionProperty = oc(deepUnion).a.deeplyNested({ maybeNumber: 0 });
+assert<
+  Has<typeof resUnionProperty, { maybeNumber?: number | null | undefined }>
+>(true);
+
+const resComplexUnion = oc(deepUnion).a.deeplyNested.maybeNumber(0);
+assert<Has<typeof resComplexUnion, number>>(true);
 
 const resNoDefault = oc(x).a.b();
 // Has string and undefined


### PR DESCRIPTION
## Description
Issue https://github.com/rimeto/ts-optchain/issues/15: Properties cannot be accessed if there is no overlap between two union types. This is typical for TypeScript (requires type guards) but it may be possible to handle this case with this library.

This appears to work, but I'm not sure if it's a good idea. The libdef works just fine so far, but the internal .ts file is very unhappy with what I've done. It also quietly allows access to all branches of a union, which is _not_ typical behavior for a library, though it is very convenient. It'd be nice to know whether to continue along this path or not.

## Test Plan
This will be a type-only change. I'll add as many cases as I can, as intersecting certain types can get very strange (all permutations of function, primitive, array, and `null`).