### PR TITLE
Support for `any` types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -44,12 +44,25 @@ interface TSOCArrayWrapper<T> {
 }
 
 /**
+ * Data accessor interface to dereference the value of an `any` type.
+ * @extends TSOCDataAccessor<any>
+ */
+interface TSOCAny extends TSOCDataAccessor<any> {
+  [K: string]: TSOCAny; // Enable deep traversal of arbitrary props
+}
+
+/**
  * `TSOCDataWrapper` selects between `TSOCArrayWrapper`, `TSOCObjectWrapper`, and `TSOCDataAccessor`
  * to wrap Arrays, Objects and all other types respectively.
  */
-type TSOCDataWrapper<T> = T extends any[]
-  ? TSOCArrayWrapper<T[number]>
-  : T extends object ? TSOCObjectWrapper<T> : TSOCDataAccessor<T>;
+type TSOCDataWrapper<T> =
+  0 extends (1 & T) // Is T any? (https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360)
+    ? TSOCAny
+    : T extends any[] // Is T array-like?
+      ? TSOCArrayWrapper<T[number]>
+      : T extends object // Is T object-like?
+        ? TSOCObjectWrapper<T>
+        : TSOCDataAccessor<T>;
 
 /**
  * An object that supports optional chaining

--- a/src/__tests__/types.ts
+++ b/src/__tests__/types.ts
@@ -9,7 +9,7 @@
  * Type only tests. Do not execute.
  */
 
-import { assert, IsExact, Has } from "conditional-type-checks";
+import { assert, IsExact, Has, IsAny } from "conditional-type-checks";
 
 import { oc } from "../proxy";
 
@@ -26,6 +26,7 @@ interface X {
     maybeNull: string | null;
     array?: (string | null)[];
     notNull: string;
+    any: any;
   };
   exists: string;
   getter?: () => string;
@@ -92,3 +93,10 @@ assert<Has<typeof resArrayDefault, undefined>>(false);
 const resMaybeNullWithDefaultNull = oc(x).a.maybeNull(null);
 assert<Has<typeof resMaybeNullWithDefaultNull, string>>(true);
 assert<Has<typeof resMaybeNullWithDefaultNull, null>>(true);
+
+// Can traverse any sub-structures
+const resAnyValue = oc(x).a.any();
+assert<IsAny<typeof resAnyValue>>(true);
+
+const resAnyDeepValue = oc(x).a.any.moo.says.the.cow('with default');
+assert<IsAny<typeof resAnyDeepValue>>(true);

--- a/src/proxy/__tests__/ts-optchain-test.ts
+++ b/src/proxy/__tests__/ts-optchain-test.ts
@@ -15,6 +15,7 @@ describe('ts-optchain', () => {
       c: number[];
       d: { e: string } | null;
       e: { f: boolean } | null;
+      g: any;
     }
 
     const x = oc<X>({
@@ -25,6 +26,15 @@ describe('ts-optchain', () => {
       c: [-100, 200, -300],
       d: null,
       e: { f: false },
+      g: {
+        moo: {
+          says: {
+            the: {
+              cow: 'hi!'
+            }
+          }
+        }
+      }
     });
 
     expect(x.a()).toEqual('hello');
@@ -35,7 +45,9 @@ describe('ts-optchain', () => {
     expect(x.d.e()).toBeUndefined();
     expect(x.d.e('optional default value')).toEqual('optional default value');
     expect(x.e.f()).toEqual(false);
-    expect((x as any).y.z.a.b.c.d.e.f.g.h.i.j.k()).toBeUndefined();
+    expect(x.g.moo.says.the.cow()).toEqual('hi!');
+    expect(x.g.moo.says.the.other.cow()).toBeUndefined();
+    expect(x.g.moo.says.the.other.cow('nothing found')).toEqual('nothing found');
   });
 
   it('optional chaining equivalence', () => {

--- a/src/transform/__tests__/transform-test.ts
+++ b/src/transform/__tests__/transform-test.ts
@@ -15,6 +15,7 @@ describe('ts-optchain', () => {
       c: number[];
       d: { e: string } | null;
       e: { f: boolean } | null;
+      g: any;
     }
 
     const x = oc<X>({
@@ -25,6 +26,15 @@ describe('ts-optchain', () => {
       c: [-100, 200, -300],
       d: null,
       e: { f: false },
+      g: {
+        moo: {
+          says: {
+            the: {
+              cow: 'hi!'
+            }
+          }
+        }
+      }
     });
 
     expect(x.a()).toEqual('hello');
@@ -35,6 +45,9 @@ describe('ts-optchain', () => {
     expect(x.d.e()).toBeUndefined();
     expect(x.d.e('optional default value')).toEqual('optional default value');
     expect(x.e.f()).toEqual(false);
+    expect(x.g.moo.says.the.cow()).toEqual('hi!');
+    expect(x.g.moo.says.the.other.cow()).toBeUndefined();
+    expect(x.g.moo.says.the.other.cow('nothing found')).toEqual('nothing found');
   });
 
   it('optional chaining equivalence', () => {

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -7,8 +7,9 @@
 
 import * as ts from 'typescript';
 
-const TSOC_TYPE_SYMBOL = 'TSOCType';
+const TSOC_ANY_SYMBOL = 'TSOCAny';
 const TSOC_DATA_ACCESSOR_SYMBOL = 'TSOCDataAccessor';
+const TSOC_TYPE_SYMBOL = 'TSOCType';
 
 export default function transformer(program: ts.Program): ts.TransformerFactory<ts.SourceFile> {
   return (context) => (file) => visitNodeAndChildren(file, program, context);
@@ -67,7 +68,11 @@ function _isValidOCType(node: ts.TypeNode | undefined): boolean {
   }
 
   if (ts.isTypeReferenceNode(node) && ts.isIdentifier(node.typeName)) {
-    return node.typeName.escapedText === TSOC_TYPE_SYMBOL || node.typeName.escapedText === TSOC_DATA_ACCESSOR_SYMBOL;
+    return (
+      node.typeName.escapedText === TSOC_ANY_SYMBOL ||
+      node.typeName.escapedText === TSOC_DATA_ACCESSOR_SYMBOL ||
+      node.typeName.escapedText === TSOC_TYPE_SYMBOL
+    );
   }
 
   return false;


### PR DESCRIPTION
## Description

Adds typings to support optional chaining of `any` values. (https://github.com/rimeto/ts-optchain/issues/12)

## Test Plan
- updated unit tests
