### PR TITLE
Fix order of operations with ternary operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-optchain",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-optchain",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Optional Chaining for TypeScript",
   "repository": {
     "type": "git",

--- a/src/__tests__/ts-optchain-test.ts
+++ b/src/__tests__/ts-optchain-test.ts
@@ -91,4 +91,10 @@ describe('ts-optchain', () => {
     const fn = <K extends { prop: string }>(v: K) => oc(v).prop();
     expect(fn({prop: 'foo'})).toEqual('foo');
   });
+
+  it('ternary order of operations', () => {
+    expect(
+      (oc('')('') ? 'bar' : 'bar')
+    ).toEqual('bar');
+  });
 });

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -120,5 +120,5 @@ function _expandOCExpression(expression: ts.Expression, defaultExpression?: ts.E
     );
   }
 
-  return ts.createParen(ts.createConditional(ts.createParen(condition), subExpression, defaultExpression || ts.createIdentifier('undefined')));
+  return ts.createParen(ts.createConditional(condition, subExpression, defaultExpression || ts.createIdentifier('undefined')));
 }

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -24,6 +24,7 @@ function visitNodeAndChildren(node: ts.Node, program: ts.Program, context: ts.Tr
 }
 
 function visitNode(node: ts.Node, program: ts.Program): ts.Node {
+
   const typeChecker = program.getTypeChecker();
   if (ts.isCallExpression(node)) {
     // Check if function call expression is an oc chain, e.g.,
@@ -53,7 +54,6 @@ function visitNode(node: ts.Node, program: ts.Program): ts.Node {
       return _expandOCExpression(node);
     }
   }
-
   return node;
 }
 
@@ -119,5 +119,6 @@ function _expandOCExpression(expression: ts.Expression, defaultExpression?: ts.E
       ts.createBinary(subExpression, ts.SyntaxKind.ExclamationEqualsToken, ts.createNull()),
     );
   }
-  return ts.createConditional(condition, subExpression, defaultExpression || ts.createIdentifier('undefined'));
+
+  return ts.createParen(ts.createConditional(ts.createParen(condition), subExpression, defaultExpression || ts.createIdentifier('undefined')));
 }


### PR DESCRIPTION
## Description
Fixes order of operations error when `oc` was combined with ternary operations. 

For example, previously,
```
oc('')('') ? 'bar' : 'bar'
```
would compile to,
```
'' != null ? '' : '' ? 'bar' : 'bar'
```
which would evaluate to empty string because of the order of operations on the javascript ternary operator. 

**This PR fixes this with an additional set of parenthesis,**
```
('' != null ? '' : '') ? 'bar' : 'bar'
```

## Test Plan
Test with new unit test and within the dependent codebase.
Compiled test code:
![image](https://user-images.githubusercontent.com/639014/62172185-474d9600-b2e6-11e9-8e07-3685d89cc31d.png)
